### PR TITLE
Update main.py

### DIFF
--- a/GlabTop2/main.py
+++ b/GlabTop2/main.py
@@ -297,13 +297,13 @@ def main(argv=None):
         print('python -m GlabTop2.main -i <config file>')
         sys.exit()
     
-    tic = time.clock()
+    tic = time.perf_counter()
     print('\nGlabTop2-py is developed by Wilco Terink\n')
     print('Version 2.0.1\n')
     glabtop = GlabTop2(cfgfile)
     glabtop.run()
 
-    toc = time.clock()
+    toc = time.perf_counter()
     
     print('\nGlabTop2-py finished in %.2f minutes' %((toc-tic)/60.))
 


### PR DESCRIPTION
time.clock() has been deprecated since 3.3, and isn't available in 3.8, and we should be using time.perf_counter() or time.process_time() to avoid users getting deprecation warnings like here:

https://www.reddit.com/r/learnpython/comments/hgfay8/complete_newbie_at_python_but_trying_to_run/